### PR TITLE
Update MicTest.vue to capitalise UseRecorder

### DIFF
--- a/src/views/MicTest.vue
+++ b/src/views/MicTest.vue
@@ -86,7 +86,7 @@
 import router from "../router";
 import MicLevel from "@/components/MicLevel.vue";
 import { onMounted, ref } from "vue";
-import useRecorder from '@/composables/useRecorder';
+import useRecorder from '@/composables/UseRecorder';
 import Swal from "sweetalert2";
 
 const dialog = ref(false);


### PR DESCRIPTION
On my computer (using WSL in Windows) npm threw an error searching for `@/composable/useRecorder` within MicTest.vue because the filename is `UseRecorder.js` (with capital U).  I fixed that bug here.  